### PR TITLE
v0.3.0_branch: Fix up minor issue in the code so it compiles and runs in the way this version is expected to

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,11 @@
 #flags= -O3 -check bounds -fp-model source
 #
 fc=gfortran
-flags=-O3
+flags=-O3 -fallow-argument-mismatch
 #flags=-march=native -ffast-math -funroll-loops -O3 -finline-limit=600
 #flags= -O3 -fbounds-check
 #
-#libs= -lcfitsio
+libs= -lcfitsio
 name=drive_SRF
 code=$(name).f
 exec=$(name).x
@@ -40,9 +40,9 @@ myobjts= $(mysrc)/bk2.o                      \
          $(mysrc)/crsexact.o                 \
          $(mysrc)/enegrd.o                   \
          $(mysrc)/gaulegf.o           	     \
-         $(mysrc)/probab.o           	       \
+         $(mysrc)/probab.o      	     \
          $(mysrc)/scattxs.o                  \
-	 		 	 $(mysrc)/write_fits.o               \
+         $(mysrc)/write_fits.o               \
          $(mysrc)/super_Compton_RF.o         \
          $(mysrc)/super_Compton_RF_fits.o    \
 

--- a/drive_SRF.f
+++ b/drive_SRF.f
@@ -17,7 +17,7 @@ c
 c........    
       implicit none
       integer nmaxp, itrans, mgi, ii
-      parameter (nmaxp=5000, itrans=70, mgi=3000)
+      parameter (nmaxp=500, itrans=70, mgi=3000)
       double precision pemin, pemax, pemax2
       double precision theta(itrans), wp(nmaxp), df(nmaxp)
       double precision skn(nmaxp,itrans)
@@ -56,8 +56,8 @@ c     Get the Gaussian quadratures for angular integration
       call gaulegf(-1.d0, 1.d0, smit, agt, mgi)
 c
 c     Produce file with all SRF's
-      call super_Compton_RF(itrans, theta, nmaxp, wp, df, skn,
-     1                      mgi, smit, agt)
+      call super_Compton_RF_fits(itrans, theta, nmaxp, wp, df, skn,
+     1                           mgi, smit, agt)
 c
 c     Get current time
       call cpu_time(tfin)

--- a/my-routines/super_Compton_RF_fits.f
+++ b/my-routines/super_Compton_RF_fits.f
@@ -1,6 +1,6 @@
 !-------------------------------------------------------------------------------------------------
       subroutine super_Compton_RF_fits(itrans, theta, nmaxp, wp, df,
-     & skn,  mgi, smit, agt)
+     1                                 skn,  mgi, smit, agt)
 c
 c     This routine writes a file with the super redistribution function (SRF) for Compton
 c     scatterting. For a given gas temperature T and final photon energy Ef, the SRF is

--- a/my-routines/write_fits.f
+++ b/my-routines/write_fits.f
@@ -186,21 +186,6 @@ c-----------------------------------------------------------------------
       integer status,readwrite,hdutype, blocksize
       integer colnum,rownum
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-    @@ -232,7 +230,6 @@ subroutine add_row_HDU(n, nmaxp, out_en_dim, out_en_ind,
-
 c Initialize status
       status=0
 c$$$      blocksize = 1
@@ -244,15 +229,6 @@ C  A simple little routine to delete a FITS file
       implicit none
       integer status,unit,blocksize
       character*(*) filename
-
-
-
-
-
-
-
-
-
 
 C  Simply return if status is greater than zero
       if (status .gt. 0)return


### PR DESCRIPTION
Fixed issues so that the v.0.3.0 code now produces the same answer as the known srf_T70_E500.fits file.

Makefile 
-- Fixed missing flags
drive_SRF.f 
-- Changed default values back to E=500, T=70, mgi=3000
-- Call the .fits version of the SRF function
my-routines/write_fits.f 
-- Removed lines erroneously included during a git operation
my-routines/super_Compton_RF_fits.f  
-- Align the second line of arguments of the function declaration